### PR TITLE
Fixes to compile with c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ SET( CALIBRATION_PROGRAMS ECalDigitisation_ContainedEvents
 SET( PROGRAMS ${PERFORMANCE_PROGRAMS} ${CALIBRATION_PROGRAMS} )
 
 # require proper C++
-ADD_DEFINITIONS( "-Wall -ansi -pedantic" )
+ADD_DEFINITIONS( "-Wall -pedantic" )
 
 # need long long for int64 for now
 ADD_DEFINITIONS( "-Wno-long-long -Wno-sign-compare -fno-strict-aliasing" )

--- a/calibration/ECalDigitisation_ContainedEvents.cc
+++ b/calibration/ECalDigitisation_ContainedEvents.cc
@@ -125,8 +125,8 @@ int main(int argc, char **argv)
 
         eCalDigitisation.Process();
 
-        std::string dataFileName(eCalDigitisation.m_outputPath + "Calibration.txt");
-        ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string	dataFileName(eCalDigitisation.m_outputPath + "Calibration.txt");
+        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;

--- a/calibration/ECalDigitisation_ContainedEvents.cc
+++ b/calibration/ECalDigitisation_ContainedEvents.cc
@@ -125,8 +125,8 @@ int main(int argc, char **argv)
 
         eCalDigitisation.Process();
 
-        std::string	dataFileName(eCalDigitisation.m_outputPath + "Calibration.txt");
-        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string dataFileName(eCalDigitisation.m_outputPath + "Calibration.txt");
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;

--- a/calibration/HCalDigitisation_ContainedEvents.cc
+++ b/calibration/HCalDigitisation_ContainedEvents.cc
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
         hCalDigitisation.Process();
 
         std::string dataFileName(hCalDigitisation.m_outputPath + "Calibration.txt");
-        ofstream    data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;
 

--- a/calibration/HCalDigitisation_DirectionCorrectionDistribution.cc
+++ b/calibration/HCalDigitisation_DirectionCorrectionDistribution.cc
@@ -89,8 +89,8 @@ int main(int argc, char **argv)
 
         hCalDigitisationDCDistribution.MakeHistograms();
 
-        std::string	dataFileName(hCalDigitisationDCDistribution.m_outputPath + "Calibration.txt");
-        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string dataFileName(hCalDigitisationDCDistribution.m_outputPath + "Calibration.txt");
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "The average direction correction applied to KaonL  : " << std::endl;
         data_file << "events with energy:                                : " << hCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;

--- a/calibration/HCalDigitisation_DirectionCorrectionDistribution.cc
+++ b/calibration/HCalDigitisation_DirectionCorrectionDistribution.cc
@@ -89,8 +89,8 @@ int main(int argc, char **argv)
 
         hCalDigitisationDCDistribution.MakeHistograms();
 
-        std::string dataFileName(hCalDigitisationDCDistribution.m_outputPath + "Calibration.txt");
-        ofstream    data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string	dataFileName(hCalDigitisationDCDistribution.m_outputPath + "Calibration.txt");
+        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "The average direction correction applied to KaonL  : " << std::endl;
         data_file << "events with energy:                                : " << hCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;

--- a/calibration/PandoraPFACalibrate_EMScale.cc
+++ b/calibration/PandoraPFACalibrate_EMScale.cc
@@ -128,8 +128,8 @@ int main(int argc, char **argv)
 
         eCalToEM.Process();
 
-        std::string dataFileName(eCalToEM.m_outputPath+"Calibration.txt");
-        ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string	dataFileName(eCalToEM.m_outputPath+"Calibration.txt");
+        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         data_file << "Electromagnetic Energy Scale PandoraPFA Calibration." << std::endl << std::endl;

--- a/calibration/PandoraPFACalibrate_EMScale.cc
+++ b/calibration/PandoraPFACalibrate_EMScale.cc
@@ -128,8 +128,8 @@ int main(int argc, char **argv)
 
         eCalToEM.Process();
 
-        std::string	dataFileName(eCalToEM.m_outputPath+"Calibration.txt");
-        std::ofstream	data_file(dataFileName.c_str(), std::ios_base::app);
+        std::string dataFileName(eCalToEM.m_outputPath+"Calibration.txt");
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         data_file << "Electromagnetic Energy Scale PandoraPFA Calibration." << std::endl << std::endl;

--- a/calibration/PandoraPFACalibrate_HadronicEnergyGaussianFit.cc
+++ b/calibration/PandoraPFACalibrate_HadronicEnergyGaussianFit.cc
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
         hadronicEnergyGaussianFit.Process();
 
         std::string dataFileName(hadronicEnergyGaussianFit.m_outputPath + "Calibration.txt");
-        ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         if (hadronicEnergyGaussianFit.m_nLC!=0)
         {

--- a/calibration/PandoraPFACalibrate_HadronicScale_ChiSquareMethod.cc
+++ b/calibration/PandoraPFACalibrate_HadronicScale_ChiSquareMethod.cc
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         chiSquaredMethod.Process();
 
         std::string dataFileName(chiSquaredMethod.m_outputPath + "Calibration.txt");
-        ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
         data_file << "_____________________________________________________________________________________" << std::endl;
         data_file << "Hadronic Energy Scale PandoraPFA Calibration performed using the Chi Squared Method." << std::endl << std::endl;
         data_file << "For kaon energy                                    : " << chiSquaredMethod.m_trueEnergy << " : " <<std::endl;

--- a/calibration/PandoraPFACalibrate_HadronicScale_TotalEnergyMethod.cc
+++ b/calibration/PandoraPFACalibrate_HadronicScale_TotalEnergyMethod.cc
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
         totalEnergyMethod.Process();
 
         std::string dataFileName(totalEnergyMethod.m_outputPath + "Calibration.txt");
-        ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
         data_file << "_____________________________________________________________________________________" << std::endl;
         data_file << "Hadronic Energy Scale PandoraPFA Calibration performed using the Total Energy Method." << std::endl << std::endl;
         data_file << "For kaon energy                                    : " << totalEnergyMethod.m_trueEnergy << " : " <<std::endl;

--- a/calibration/PandoraPFACalibrate_MipResponse.cc
+++ b/calibration/PandoraPFACalibrate_MipResponse.cc
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
         geVToMIP.MakeHistograms();
 
         std::string dataFileName(geVToMIP.m_outputPath + "Calibration.txt");
-        ofstream    data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;

--- a/calibration/SimCaloHitEnergyDistribution.cc
+++ b/calibration/SimCaloHitEnergyDistribution.cc
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         simCaloHitEnergyDistribution.MakeHistograms();
 
         std::string dataFileName(simCaloHitEnergyDistribution.m_outputPath + "Calibration.txt");
-        ofstream    data_file(dataFileName.c_str(), std::ios_base::app);
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
 
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;


### PR DESCRIPTION
Removed the ansi flag (which equals c++98)
and added "std::" for ofstream to compile with gcc481 and c++11