### PR TITLE
Changes for a separate ecal region calibration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ AUX_SOURCE_DIRECTORY( ./src PandoraAnalysis_SRCS )
 SET( PERFORMANCE_PROGRAMS AnalysePerformance
     AnalysePerformanceFull )
 SET( CALIBRATION_PROGRAMS ECalDigitisation_ContainedEvents
+    ECalDigitisation_DirectionCorrectionDistribution
     HCalDigitisation_ContainedEvents
     HCalDigitisation_DirectionCorrectionDistribution
     PandoraPFACalibrate_MipResponse

--- a/calibration/ECalDigitisation_ContainedEvents.cc
+++ b/calibration/ECalDigitisation_ContainedEvents.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/calibration/ECalDigitisation_ContainedEvents.cc
- *
+ * 
  *  @brief  Mean calo hit energy for photon events contained in ECal.  Used for setting digitisation constant in ECal (CalibrECAL).
- *
+ * 
  *  $Log: $
  */
 
@@ -24,7 +24,7 @@
 /**
  *  @brief  ECalDigitisation class
  */
-class ECalDigitisation
+class ECalDigitisation 
 {
 public:
     /**
@@ -48,9 +48,9 @@ public:
     float           m_calibrationAccuracy;  ///< Fractional accuracy target for reconstructed energy
     std::string     m_outputPath;           ///< Output path to send results
     float           m_fitPercentage;        ///< Percentage of continuous data with narrowest range for Gaussian fit
-    std::string     m_element;              ///< Detector component (Barrel, EndCap or Other)
+    std::string     m_element;              ///< Detector component (Barrel or EndCap)
     float           m_lowerCosThetaCut;     ///< Lower cosTheta cut defining m_element
-    float           m_upperCosTheraCut;     ///< Lower cosTheta cut defining m_element
+    float           m_upperCosThetaCut;     ///< Upper cosTheta cut defining m_element
 
 // Outputs
     float           m_amplitude;            ///< Amplitude of Gaussian fit
@@ -70,7 +70,7 @@ private:
     void CreateHistogram();
 
     /**
-     *  @brief  Fill ECal calo hit energy histogram
+     *  @brief  Fill ECal calo hit energy histogram 
     */
     void FillHistogram();
 
@@ -100,11 +100,11 @@ typedef std::vector<float> FloatVector;
 
 /**
  *  @brief  Parse the command line arguments, setting the application parameters
- *
+ * 
  *  @param  argc argument count
  *  @param  argv argument vector
  *  @param  eCalDigitisation to receive the application parameters
- *
+ * 
  *  @return success
  */
 bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation);
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
         data_file << "Digitisation of the ECal " + eCalDigitisation.m_element + "                    : " << std::endl;
         data_file << "Element                                            : " << eCalDigitisation.m_element << std::endl;
         data_file << "Lower abs(cosTheta) cut defining element           : " << eCalDigitisation.m_lowerCosThetaCut << std::endl;
-        data_file << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosTheraCut << std::endl;
+        data_file << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosThetaCut << std::endl;
         data_file << "For Photon energy                                  : " << eCalDigitisation.m_trueEnergy << " : /GeV" <<std::endl;
         data_file << "Gaussian fit to ECal calorimeter hit energy has    : " << std::endl;
         data_file << "the following parameters, fit uses 90% data with   : " << std::endl;
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         std::cout << "Digitisation of the ECal " + eCalDigitisation.m_element + "                    : " << std::endl;
         std::cout << "Element                                            : " << eCalDigitisation.m_element << std::endl;
         std::cout << "Lower abs(cosTheta) cut defining element           : " << eCalDigitisation.m_lowerCosThetaCut << std::endl;
-        std::cout << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosTheraCut << std::endl;
+        std::cout << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosThetaCut << std::endl;
         std::cout << "For Photon energy                                  : " << eCalDigitisation.m_trueEnergy << " : /GeV" <<std::endl;
         std::cout << "Gaussian fit to ECal calorimeter hit energy has    : " << std::endl;
         std::cout << "the following parameters, fit uses 90% data with   : " << std::endl;
@@ -184,7 +184,7 @@ ECalDigitisation::ECalDigitisation() :
     m_fitPercentage(90.f),
     m_element(""),
     m_lowerCosThetaCut(0.f),
-    m_upperCosTheraCut(1.f),
+    m_upperCosThetaCut(1.f),
     m_amplitude(std::numeric_limits<float>::max()),
     m_mean(std::numeric_limits<float>::max()),
     m_stdDev(std::numeric_limits<float>::max()),
@@ -240,7 +240,7 @@ void ECalDigitisation::PrepareHistogram()
 
         if (1 == nPfoTargetsTotal && 1 == nPfoTargetsPhotons && isContained)
         {
-            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosTheraCut)
+            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosThetaCut)
             {
                 if (eCalTotalCaloHitEnergy > m_maxHistogramEnergy)
                     m_maxHistogramEnergy = eCalTotalCaloHitEnergy;
@@ -275,7 +275,7 @@ void ECalDigitisation::FillHistogram()
     m_pTChain->SetBranchAddress("nPfoTargetsPhotons",&nPfoTargetsPhotons);
     m_pTChain->SetBranchAddress("pfoTargetCosTheta", &pfoTargetCosTheta);
 
-    for (unsigned int i = 0; i < m_pTChain->GetEntries(); i++)
+    for (unsigned int i = 0; i < m_pTChain->GetEntries(); i++) 
     {
         m_pTChain->GetEntry(i);
 
@@ -284,7 +284,7 @@ void ECalDigitisation::FillHistogram()
 
         if (1 == nPfoTargetsTotal && 1 == nPfoTargetsPhotons && isContained)
         {
-            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosTheraCut)
+            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosThetaCut)
             {
                 m_histogram->Fill(eCalTotalCaloHitEnergy);
                 m_nEventsECalHist++;
@@ -358,7 +358,7 @@ void ECalDigitisation::RMSFitPercentageRange()
 
             if (sumn < (m_fitPercentage/100) * total)
             {
-                // These variables define the final sums required once we have considered X% of data, anything else is
+                // These variables define the final sums required once we have considered X% of data, anything else is 
                 // continuously overwritten.
                 sumn += yi;
                 sumx += yi * binx;
@@ -385,17 +385,17 @@ void ECalDigitisation::RMSFitPercentageRange()
                 low = m_histogram->GetBinLowEdge(istart);
                 m_fitRangeLow = m_histogram->GetBinLowEdge(istart) + (0.5 * m_histogram->GetBinWidth(istart));
             }
-
+            
             high = m_histogram->GetBinLowEdge(iend);
             rmsmin = localRms;
             m_fitRangeHigh = m_histogram->GetBinLowEdge(iend) + (0.5 * m_histogram->GetBinWidth(iend));
         }
     }
-
+    
     m_rMSFitRange = rmsmin;
-
+    
     std::cout << m_histogram->GetName() << " (" << m_histogram->GetEntries() << " entries), rawrms: " << rawRms << ", rmsx: " << rmsmin
-              << " (" << low << "-" << high << "), low_fit and high_fit " << " (" << m_fitRangeLow << "-" << m_fitRangeHigh
+              << " (" << low << "-" << high << "), low_fit and high_fit " << " (" << m_fitRangeLow << "-" << m_fitRangeHigh 
               << "), << mean: " << mean << std::endl;
 }
 
@@ -498,13 +498,13 @@ void ECalDigitisation::Fit()
             pCanvas->SaveAs(dotCOutputFilename);
             delete pCanvas;
         }
-
+        
         else
         {
             std::cout << "Histogram is empty, no fit possible." << std::endl;
         }
     }
-
+    
     catch (const std::runtime_error& e)
     {
         std::cout << "An exception occurred. " << e.what() << '\n';
@@ -544,7 +544,7 @@ bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation
             eCalDigitisation.m_lowerCosThetaCut = atof(optarg);
             break;
         case 'j':
-            eCalDigitisation.m_upperCosTheraCut = atof(optarg);
+            eCalDigitisation.m_upperCosThetaCut = atof(optarg);
             break;
         case 'f':
         case 'h':
@@ -557,8 +557,8 @@ bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation
                       << "    -d        (mandatory, output path to send results to)                                             " << std::endl
                       << "    -e value  (optional, fit percentage used for calibration, default 90% of data with narrowest rms) " << std::endl
                       << "    -g        (mandatory, element of the detector being calibrated (Barrel or EndCap))                " << std::endl
-                      << "    -i value  (mandatory, lower abs cos theta cut defining element, default 0)                        " << std::endl
-                      << "    -j value  (mandatory, upper abs cos theta cut defining element, default 1)                        " << std::endl
+                      << "    -i value  (mandatory, lower abs cos theta cut defining element, usually 0)                        " << std::endl
+                      << "    -j value  (mandatory, upper abs cos theta cut defining element, usually 1)                        " << std::endl
                       << std::endl;
             return false;
         }

--- a/calibration/ECalDigitisation_ContainedEvents.cc
+++ b/calibration/ECalDigitisation_ContainedEvents.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/calibration/ECalDigitisation_ContainedEvents.cc
- * 
+ *
  *  @brief  Mean calo hit energy for photon events contained in ECal.  Used for setting digitisation constant in ECal (CalibrECAL).
- * 
+ *
  *  $Log: $
  */
 
@@ -24,7 +24,7 @@
 /**
  *  @brief  ECalDigitisation class
  */
-class ECalDigitisation 
+class ECalDigitisation
 {
 public:
     /**
@@ -48,6 +48,9 @@ public:
     float           m_calibrationAccuracy;  ///< Fractional accuracy target for reconstructed energy
     std::string     m_outputPath;           ///< Output path to send results
     float           m_fitPercentage;        ///< Percentage of continuous data with narrowest range for Gaussian fit
+    std::string     m_element;              ///< Detector component (Barrel, EndCap or Other)
+    float           m_lowerCosThetaCut;     ///< Lower cosTheta cut defining m_element
+    float           m_upperCosTheraCut;     ///< Lower cosTheta cut defining m_element
 
 // Outputs
     float           m_amplitude;            ///< Amplitude of Gaussian fit
@@ -67,7 +70,7 @@ private:
     void CreateHistogram();
 
     /**
-     *  @brief  Fill ECal calo hit energy histogram 
+     *  @brief  Fill ECal calo hit energy histogram
     */
     void FillHistogram();
 
@@ -97,11 +100,11 @@ typedef std::vector<float> FloatVector;
 
 /**
  *  @brief  Parse the command line arguments, setting the application parameters
- * 
+ *
  *  @param  argc argument count
  *  @param  argv argument vector
  *  @param  eCalDigitisation to receive the application parameters
- * 
+ *
  *  @return success
  */
 bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation);
@@ -131,7 +134,10 @@ int main(int argc, char **argv)
         data_file << "_____________________________________________________________________________________" << std::endl;
         std::cout << "_____________________________________________________________________________________" << std::endl;
 
-        data_file << "Digitisation of the ECal.                          : " << std::endl << std::endl;
+        data_file << "Digitisation of the ECal " + eCalDigitisation.m_element + "                    : " << std::endl;
+        data_file << "Element                                            : " << eCalDigitisation.m_element << std::endl;
+        data_file << "Lower abs(cosTheta) cut defining element           : " << eCalDigitisation.m_lowerCosThetaCut << std::endl;
+        data_file << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosTheraCut << std::endl;
         data_file << "For Photon energy                                  : " << eCalDigitisation.m_trueEnergy << " : /GeV" <<std::endl;
         data_file << "Gaussian fit to ECal calorimeter hit energy has    : " << std::endl;
         data_file << "the following parameters, fit uses 90% data with   : " << std::endl;
@@ -141,7 +147,10 @@ int main(int argc, char **argv)
         data_file << "Standard Deviation                                 : " << eCalDigitisation.m_stdDev << " : " <<std::endl;
         data_file << "The total number of events considered was          : " << eCalDigitisation.m_nEventsECalHist << " : " <<std::endl<<std::endl;
 
-        std::cout << "Digitisation of the ECal.                          : " << std::endl << std::endl;
+        std::cout << "Digitisation of the ECal " + eCalDigitisation.m_element + "                    : " << std::endl;
+        std::cout << "Element                                            : " << eCalDigitisation.m_element << std::endl;
+        std::cout << "Lower abs(cosTheta) cut defining element           : " << eCalDigitisation.m_lowerCosThetaCut << std::endl;
+        std::cout << "Upper abs(cosTheta) cut defining element           : " << eCalDigitisation.m_upperCosTheraCut << std::endl;
         std::cout << "For Photon energy                                  : " << eCalDigitisation.m_trueEnergy << " : /GeV" <<std::endl;
         std::cout << "Gaussian fit to ECal calorimeter hit energy has    : " << std::endl;
         std::cout << "the following parameters, fit uses 90% data with   : " << std::endl;
@@ -173,6 +182,9 @@ ECalDigitisation::ECalDigitisation() :
     m_calibrationAccuracy(0.02),
     m_outputPath(""),
     m_fitPercentage(90.f),
+    m_element(""),
+    m_lowerCosThetaCut(0.f),
+    m_upperCosTheraCut(1.f),
     m_amplitude(std::numeric_limits<float>::max()),
     m_mean(std::numeric_limits<float>::max()),
     m_stdDev(std::numeric_limits<float>::max()),
@@ -228,8 +240,11 @@ void ECalDigitisation::PrepareHistogram()
 
         if (1 == nPfoTargetsTotal && 1 == nPfoTargetsPhotons && isContained)
         {
-            if (eCalTotalCaloHitEnergy > m_maxHistogramEnergy)
-                m_maxHistogramEnergy = eCalTotalCaloHitEnergy;
+            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosTheraCut)
+            {
+                if (eCalTotalCaloHitEnergy > m_maxHistogramEnergy)
+                    m_maxHistogramEnergy = eCalTotalCaloHitEnergy;
+            }
         }
     }
 }
@@ -238,8 +253,8 @@ void ECalDigitisation::PrepareHistogram()
 
 void ECalDigitisation::CreateHistogram()
 {
-    std::string Name = "CaloHitEnergyECal";
-    std::string Title = "Calorimeter Hit Energy ECal (1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && Contained in ECal)";
+    std::string Name = "CaloHitEnergyECal" + m_element;
+    std::string Title = "Calorimeter Hit Energy ECal " + m_element + " (1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && Contained in ECal)";
     int binNumber = static_cast<int>( m_maxHistogramEnergy / ( m_calibrationAccuracy * m_trueEnergy ) );
     m_histogram = new TH1F(Name.c_str(), Title.c_str(), binNumber, 0., m_maxHistogramEnergy);
     m_histogram->GetXaxis()->SetTitle("Calorimeter Hit Energy / GeV");
@@ -260,7 +275,7 @@ void ECalDigitisation::FillHistogram()
     m_pTChain->SetBranchAddress("nPfoTargetsPhotons",&nPfoTargetsPhotons);
     m_pTChain->SetBranchAddress("pfoTargetCosTheta", &pfoTargetCosTheta);
 
-    for (unsigned int i = 0; i < m_pTChain->GetEntries(); i++) 
+    for (unsigned int i = 0; i < m_pTChain->GetEntries(); i++)
     {
         m_pTChain->GetEntry(i);
 
@@ -269,8 +284,11 @@ void ECalDigitisation::FillHistogram()
 
         if (1 == nPfoTargetsTotal && 1 == nPfoTargetsPhotons && isContained)
         {
-            m_histogram->Fill(eCalTotalCaloHitEnergy);
-            m_nEventsECalHist++;
+            if (m_lowerCosThetaCut < CosTheta && CosTheta < m_upperCosTheraCut)
+            {
+                m_histogram->Fill(eCalTotalCaloHitEnergy);
+                m_nEventsECalHist++;
+            }
         }
     }
 }
@@ -340,7 +358,7 @@ void ECalDigitisation::RMSFitPercentageRange()
 
             if (sumn < (m_fitPercentage/100) * total)
             {
-                // These variables define the final sums required once we have considered X% of data, anything else is 
+                // These variables define the final sums required once we have considered X% of data, anything else is
                 // continuously overwritten.
                 sumn += yi;
                 sumx += yi * binx;
@@ -367,17 +385,17 @@ void ECalDigitisation::RMSFitPercentageRange()
                 low = m_histogram->GetBinLowEdge(istart);
                 m_fitRangeLow = m_histogram->GetBinLowEdge(istart) + (0.5 * m_histogram->GetBinWidth(istart));
             }
-            
+
             high = m_histogram->GetBinLowEdge(iend);
             rmsmin = localRms;
             m_fitRangeHigh = m_histogram->GetBinLowEdge(iend) + (0.5 * m_histogram->GetBinWidth(iend));
         }
     }
-    
+
     m_rMSFitRange = rmsmin;
-    
+
     std::cout << m_histogram->GetName() << " (" << m_histogram->GetEntries() << " entries), rawrms: " << rawRms << ", rmsx: " << rmsmin
-              << " (" << low << "-" << high << "), low_fit and high_fit " << " (" << m_fitRangeLow << "-" << m_fitRangeHigh 
+              << " (" << low << "-" << high << "), low_fit and high_fit " << " (" << m_fitRangeLow << "-" << m_fitRangeHigh
               << "), << mean: " << mean << std::endl;
 }
 
@@ -463,30 +481,30 @@ void ECalDigitisation::Fit()
             m_mean = Gaussian_Fit_Func->GetParameter(1);
             m_stdDev = std::pow(Gaussian_Fit_Func->GetParameter(2),-0.5);
 
-            std::string canvasName = "ECalDigitisation";
-            std::string canvasTitle = "ECal Digitisation";
+            std::string canvasName = m_element + "ECalDigitisation";
+            std::string canvasTitle = m_element + " ECal Digitisation";
             TCanvas *pCanvas = new TCanvas(canvasName.c_str(),canvasTitle.c_str(),200,10,600,500);
             pCanvas->cd();
             m_histogram->GetYaxis()->SetTitle("Entries");
-            std::string xAxisTitle = "Calorimeter Hit Energy in ECal / GeV";
+            std::string xAxisTitle = "Calorimeter Hit Energy in ECal " + m_element + "/ GeV";
             m_histogram->GetXaxis()->SetTitle(xAxisTitle.c_str());
             m_histogram->Draw("");
             Gaussian_Fit_Func->Draw("same");
 
-            TString pngOutputFilename = m_outputPath + "Calorimeter_Hit_Energies_ECal_Digitisation.png";
-            TString dotCOutputFilename = m_outputPath + "Calorimeter_Hit_Energies_ECal_Digitisation.C";
+            TString pngOutputFilename = m_outputPath + "Calorimeter_Hit_Energies_ECal_" + m_element + "_Digitisation.png";
+            TString dotCOutputFilename = m_outputPath + "Calorimeter_Hit_Energies_ECal_" + m_element + "_Digitisation.C";
 
             pCanvas->SaveAs(pngOutputFilename);
             pCanvas->SaveAs(dotCOutputFilename);
             delete pCanvas;
         }
-        
+
         else
         {
             std::cout << "Histogram is empty, no fit possible." << std::endl;
         }
     }
-    
+
     catch (const std::runtime_error& e)
     {
         std::cout << "An exception occurred. " << e.what() << '\n';
@@ -500,7 +518,7 @@ bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation
 {
     int c(0);
 
-    while (((c = getopt(argc, argv, "a:b:c:d:e:f")) != -1) || (argc == 1))
+    while (((c = getopt(argc, argv, "a:b:c:d:e:g:i:j:")) != -1) || (argc == 1))
     {
         switch (c)
         {
@@ -519,7 +537,18 @@ bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation
         case 'e':
             eCalDigitisation.m_fitPercentage = atof(optarg);
             break;
+        case 'g':
+            eCalDigitisation.m_element = optarg;
+            break;
+        case 'i':
+            eCalDigitisation.m_lowerCosThetaCut = atof(optarg);
+            break;
+        case 'j':
+            eCalDigitisation.m_upperCosTheraCut = atof(optarg);
+            break;
         case 'f':
+        case 'h':
+        case 'k':
         default:
             std::cout << std::endl << "Calibrate " << std::endl
                       << "    -a        (mandatory, input file name(s), can include wildcards if string is in quotes)           " << std::endl
@@ -527,6 +556,9 @@ bool ParseCommandLine(int argc, char *argv[], ECalDigitisation &eCalDigitisation
                       << "    -c value  (optional, fractional accuracy to calibrate CalibrECAL to, default 0.02)                " << std::endl
                       << "    -d        (mandatory, output path to send results to)                                             " << std::endl
                       << "    -e value  (optional, fit percentage used for calibration, default 90% of data with narrowest rms) " << std::endl
+                      << "    -g        (mandatory, element of the detector being calibrated (Barrel or EndCap))                " << std::endl
+                      << "    -i value  (mandatory, lower abs cos theta cut defining element, default 0)                        " << std::endl
+                      << "    -j value  (mandatory, upper abs cos theta cut defining element, default 1)                        " << std::endl
                       << std::endl;
             return false;
         }

--- a/calibration/ECalDigitisation_DirectionCorrectionDistribution.cc
+++ b/calibration/ECalDigitisation_DirectionCorrectionDistribution.cc
@@ -1,0 +1,263 @@
+/**
+ *  @file   PandoraAnalysis/calibration/ECalDigitisation_DirectionCorrectionDistribution.cc
+ *
+ *  @brief  Generate average direction correction applied to photon events in ECal Barrel, EndCap and Other.  Used for setting
+ *          digitisation constant CalibrECalOther.
+ *
+ *  $Log: $
+ */
+
+#include "TApplication.h"
+#include "TCanvas.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TFitResult.h"
+#include "TH1F.h"
+#include "TROOT.h"
+#include "TSystemDirectory.h"
+
+#include <iostream>
+#include <cstdlib>
+#include <unistd.h>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+
+/**
+ *  @brief  ECalDigitisationDCDistribution class
+ */
+class ECalDigitisationDCDistribution
+{
+public:
+    /**
+     *  @brief  Constructor
+    */
+    ECalDigitisationDCDistribution();
+
+    /**
+     *  @brief  Destructor
+     */
+    ~ECalDigitisationDCDistribution();
+
+    /**
+     *  @brief  Create histograms
+    */
+    void MakeHistograms();
+
+// Inputs Set By Parsing Command Line
+    std::string     m_inputPhotonRootFiles;                  ///< Input root files - Photon
+    float           m_trueEnergy;                           ///< True energy (opposed to kinetic) of particle being simulated
+    std::string     m_outputPath;                           ///< Output path to send results
+
+// Outputs
+    TH1F           *m_hECalBarrelDirectionCorrectionSimCaloHit;    ///< Histogram of direction corrections applied to SimCalorimeterHits in ECal Barrel
+    TH1F           *m_hECalEndCapDirectionCorrectionSimCaloHit;    ///< Histogram of direction corrections applied to SimCalorimeterHits in ECal EndCap
+    TH1F           *m_hECalOtherDirectionCorrectionSimCaloHit;     ///< Histogram of direction corrections applied to SimCalorimeterHits in ECal Other
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
+ *  @brief  Parse the command line arguments, setting the application parameters
+ *
+ *  @param  argc argument count
+ *  @param  argv argument vector
+ *  @param  parameters to receive the application parameters
+ *
+ *  @return success
+ */
+
+bool ParseCommandLine(int argc, char *argv[], ECalDigitisationDCDistribution &eCalDigitisationDCDistribution);
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int main(int argc, char **argv)
+{
+    TApplication *pTApplication = NULL;
+
+    gROOT->SetBatch();
+
+    try
+    {
+        ECalDigitisationDCDistribution eCalDigitisationDCDistribution;
+
+        if (!ParseCommandLine(argc, argv, eCalDigitisationDCDistribution))
+            return 1;
+
+        pTApplication = new TApplication("MyTest", &argc, argv);
+
+        eCalDigitisationDCDistribution.MakeHistograms();
+
+        std::string dataFileName(eCalDigitisationDCDistribution.m_outputPath + "Calibration.txt");
+        std::ofstream data_file(dataFileName.c_str(), std::ios_base::app);
+
+        data_file << "The average direction correction applied to Photon  : " << std::endl;
+        data_file << "events with energy:                                : " << eCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;
+        data_file << "in the ECal EndCap is given by:                    : " << std::endl;
+        data_file << "Mean Direction Correction ECalEndCap:              : " << eCalDigitisationDCDistribution.m_hECalEndCapDirectionCorrectionSimCaloHit->GetMean() << " : " <<std::endl<<std::endl;
+
+        std::cout << "The average direction correction applied to Photon  : " << std::endl;
+        std::cout << "events with energy:                                : " << eCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;
+        std::cout << "in the ECal EndCap is given by:                    : " << std::endl;
+        std::cout << "Mean Direction Correction ECalEndCap:              : " << eCalDigitisationDCDistribution.m_hECalEndCapDirectionCorrectionSimCaloHit->GetMean() << " : " <<std::endl<<std::endl;
+
+        data_file << "The average direction correction applied to Photon  : " << std::endl;
+        data_file << "events with energy:                                : " << eCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;
+        data_file << "in the ECalOther (i.e. ECal Ring) is given by:     : " << std::endl;
+        data_file << "Mean Direction Correction ECalOther:               : " << eCalDigitisationDCDistribution.m_hECalOtherDirectionCorrectionSimCaloHit->GetMean() << " : " <<std::endl<<std::endl;
+
+        std::cout << "The average direction correction applied to Photon  : " << std::endl;
+        std::cout << "events with energy:                                : " << eCalDigitisationDCDistribution.m_trueEnergy << " : /GeV" <<std::endl;
+        std::cout << "in the ECalOther (i.e. ECal Ring) is given by:     : " << std::endl;
+        std::cout << "Mean Direction Correction ECalOther:               : " << eCalDigitisationDCDistribution.m_hECalOtherDirectionCorrectionSimCaloHit->GetMean() << " : " <<std::endl<<std::endl;
+
+        data_file.close();
+        delete pTApplication;
+    }
+
+    catch (std::exception &exception)
+    {
+        std::cout << "Exception caught " << exception.what() << std::endl;
+        delete pTApplication;
+        return 1;
+    }
+
+    return 0;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+ECalDigitisationDCDistribution::ECalDigitisationDCDistribution() :
+    m_inputPhotonRootFiles(""),
+    m_trueEnergy(std::numeric_limits<float>::max()),
+    m_outputPath(""),
+    m_hECalBarrelDirectionCorrectionSimCaloHit(NULL),
+    m_hECalEndCapDirectionCorrectionSimCaloHit(NULL),
+    m_hECalOtherDirectionCorrectionSimCaloHit(NULL)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+ECalDigitisationDCDistribution::~ECalDigitisationDCDistribution()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ECalDigitisationDCDistribution::MakeHistograms()
+{
+    m_hECalBarrelDirectionCorrectionSimCaloHit = new TH1F("ECalBarrelDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal Barrel (1==nPfoTargetsTotal && 1==nPfoTargetsNeutralHadrons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalBarrelDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Sim Calo Hit Direction Correction");
+    m_hECalBarrelDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
+    m_hECalEndCapDirectionCorrectionSimCaloHit = new TH1F("ECalEndCapDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal EndCap (1==nPfoTargetsTotal && 1==nPfoTargetsNeutralHadrons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalEndCapDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Sim Calo Hit Direction Correction");
+    m_hECalEndCapDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
+    m_hECalOtherDirectionCorrectionSimCaloHit = new TH1F("ECalOtherDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal Other (1==nPfoTargetsTotal && 1==nPfoTargetsNeutralHadrons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalOtherDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Sim Calo Hit Direction Correction");
+    m_hECalOtherDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
+    unsigned int found_slash = m_inputPhotonRootFiles.find_last_of("/");
+    std::string path = m_inputPhotonRootFiles.substr(0,found_slash);
+    std::string file = m_inputPhotonRootFiles.substr(found_slash+1);
+
+    unsigned int found_star = file.find_last_of("*");
+    std::string file_prefix = file.substr(0,found_star);
+    std::string file_suffix = file.substr(found_star+1);
+
+    TSystemDirectory dir(path.c_str(), path.c_str());
+    TList *pTList = dir.GetListOfFiles();
+
+    if (pTList)
+    {
+        TSystemFile *pTSystemFile;
+        TString fname;
+        TIter next(pTList);
+        while ((pTSystemFile = (TSystemFile*)next()))
+        {
+            fname = pTSystemFile->GetName();
+
+            if (!pTSystemFile->IsDirectory() && fname.EndsWith(file_suffix.c_str()) && fname.BeginsWith(file_prefix.c_str()))
+            {
+                TString filename(path + "/" + fname);
+                TFile *pTFile = new TFile(filename);
+                TH1F *pTH1FECalBarrelDirectionCorrectionSimCaloHit = (TH1F*) pTFile->Get("ECalBarrelDirectionCorrectionSimCaloHit");
+                TH1F *pTH1FECalEndCapDirectionCorrectionSimCaloHit = (TH1F*) pTFile->Get("ECalEndCapDirectionCorrectionSimCaloHit");
+                TH1F *pTH1FECalOtherDirectionCorrectionSimCaloHit = (TH1F*) pTFile->Get("ECalOtherDirectionCorrectionSimCaloHit");
+
+                if (pTH1FECalBarrelDirectionCorrectionSimCaloHit!=NULL)
+                    m_hECalBarrelDirectionCorrectionSimCaloHit->Add(pTH1FECalBarrelDirectionCorrectionSimCaloHit,1.0);
+
+                if (pTH1FECalEndCapDirectionCorrectionSimCaloHit!=NULL)
+                    m_hECalEndCapDirectionCorrectionSimCaloHit->Add(pTH1FECalEndCapDirectionCorrectionSimCaloHit,1.0);
+
+                if (pTH1FECalOtherDirectionCorrectionSimCaloHit!=NULL)
+                    m_hECalOtherDirectionCorrectionSimCaloHit->Add(pTH1FECalOtherDirectionCorrectionSimCaloHit,1.0);
+
+                delete pTH1FECalBarrelDirectionCorrectionSimCaloHit;
+                delete pTH1FECalEndCapDirectionCorrectionSimCaloHit;
+                delete pTH1FECalOtherDirectionCorrectionSimCaloHit;
+                delete pTFile;
+            }
+        }
+    }
+
+    m_hECalBarrelDirectionCorrectionSimCaloHit->Sumw2();
+    m_hECalEndCapDirectionCorrectionSimCaloHit->Sumw2();
+    m_hECalOtherDirectionCorrectionSimCaloHit->Sumw2();
+
+    TCanvas *pCanvas = new TCanvas("Canvas", "Canvas", 5000, 5000);
+    pCanvas->Divide(1,3);
+
+    pCanvas->cd(1);
+    m_hECalBarrelDirectionCorrectionSimCaloHit->Draw();
+
+    pCanvas->cd(2);
+    m_hECalEndCapDirectionCorrectionSimCaloHit->Draw();
+
+    pCanvas->cd(3);
+    m_hECalOtherDirectionCorrectionSimCaloHit->Draw();
+
+    TString pngOutputFilename = m_outputPath + "Direction_Correction_Distribution_ECal_" + TString::Format("%i",int(m_trueEnergy + 0.5)) + "_GeV_Photon.png";
+    TString dotCOutputFilename = m_outputPath + "Direction_Correction_Distribution_ECal_" + TString::Format("%i",int(m_trueEnergy + 0.5)) + "_GeV_Photon.C";
+
+    pCanvas->SaveAs(pngOutputFilename);
+    pCanvas->SaveAs(dotCOutputFilename);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool ParseCommandLine(int argc, char *argv[], ECalDigitisationDCDistribution &eCalDigitisationDCDistribution)
+{
+    int c(0);
+
+    while (((c = getopt(argc, argv, "a:b:c:d")) != -1) || (argc == 1))
+    {
+        switch (c)
+        {
+        case 'a':
+            eCalDigitisationDCDistribution.m_inputPhotonRootFiles = optarg;
+            break;
+        case 'b':
+            eCalDigitisationDCDistribution.m_trueEnergy = atof(optarg);
+            break;
+        case 'c':
+            eCalDigitisationDCDistribution.m_outputPath = optarg;
+            break;
+        case 'd':
+        default:
+            std::cout << std::endl << "Calibrate " << std::endl
+                      << "    -a        (mandatory, input file name(s), can include wildcards if string is in quotes)   " << std::endl
+                      << "    -b value  (mandatory, true energy of photon being used for calibration)                    " << std::endl
+                      << "    -c        (mandatory, output path to send results to)                                     " << std::endl
+                      << std::endl;
+            return false;
+        }
+    }
+    return true;
+}

--- a/include/CalibrationHelper.h
+++ b/include/CalibrationHelper.h
@@ -1,6 +1,6 @@
 /**
  *  @file   PandoraAnalysis/include/CalibrationHelper.h
- *
+ * 
  *  @brief  Header file for the calibration helper class.
  */
 
@@ -70,7 +70,7 @@ public:
 
     /**
      *  @brief  Constructor
-     *
+     * 
      *  @param  settings the settings
      */
     CalibrationHelper(const Settings &settings);
@@ -82,7 +82,7 @@ public:
 
     /**
      *  @brief  Produces the calibration data
-     *
+     * 
      *  @param  pLCEvent the lc event
      *  @param  particleVector reconstructed particle vector for the lc event
      *  @param  nPfoTargetsTotal number of total targets
@@ -95,7 +95,7 @@ public:
 
     /**
      *  @brief  Set branch addresses for calibration variables
-     *
+     * 
      *  @param  pTTree tree to set branch addresses to
      */
     void SetBranchAddresses(TTree *pTTree);
@@ -107,7 +107,7 @@ public:
 
     /**
      *  @brief  Set directory for calibration histograms
-     *
+     * 
      *  @param  pTFile directory to set histograms to
      */
     void SetHistogramDirectories(TFile *pTFile);
@@ -125,14 +125,14 @@ public:
 private:
     /**
      *  @brief  Get the minimum number of HCal layers between any calo hit in the ParticleVector and the edge of the detector
-     *
+     * 
      *  @param  pParticleVector to be examined
      */
     int GetMinNHCalLayersFromEdge(const ParticleVector &pParticleVector) const;
 
     /**
      *  @brief  Read and save the calorimeter hit information for a specific collection
-     *
+     * 
      *  @param  pLCEvent the lc event
      *  @param  collectionNames the collection to be read
      *  @param  hitEnergySum the sum of the hit energy for the collection
@@ -141,7 +141,7 @@ private:
 
     /**
      *  @brief  Read and save the simcalorimeter hit information for a specific collection
-     *
+     * 
      *  @param  pLCEvent the lc event
      *  @param  collectionNames the collection to be read
      *  @param  hitEnergySum the sum of the hit energy for the collection
@@ -150,7 +150,7 @@ private:
 
     /**
      *  @brief  Add the direction corrected SimCaloHits and the direction corrections for a particular collection to separate histograms
-     *
+     * 
      *  @param  pLCEvent a collection in the lc event
      *  @param  collectionNames a collection in the lc event
      *  @param  Barrel, Endcap, Other for the HCal collection
@@ -161,7 +161,7 @@ private:
 
     /**
      *  @brief  Add the direction corrected calo hits for a particular collection to a histogram
-     *
+     * 
      *  @param  pLCEvent a collection in the lc event
      *  @param  collectionNames a collection in the lc event
      *  @param  pTH1F histogram to store direction corrected calo hits
@@ -170,14 +170,14 @@ private:
 
     /**
      *  @brief  Get the minimum number of HCal layers between a calo hit and the edge of the detector
-     *
+     * 
      *  @param  pCaloHit to be examined
      */
     int GetNHCalLayersFromEdge(const EVENT::CalorimeterHit *const pCaloHit) const;
 
     /**
      *  @brief  Get the radial distance between a calo hit in the HCal and the edge of the HCal
-     *
+     * 
      *  @param  pCaloHit to be examined
      *  @param  symmetryOrder of the region of the HCal the hit is in i.e. Barrel, Endcap, Ring
      *  @param  phi0 of the region of the HCal the hit is in i.e. Barrel, Endcap, Ring
@@ -185,7 +185,7 @@ private:
     float GetMaximumRadius(const EVENT::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
 
     /**
-     *  @brief A helper function to access geometry information via DD4HEP
+     *  @brief A helper function to access geometry information via DD4HEP 
      *
      *  @param includeFlag calorimeter propereties to include
      *  @param excludeFlag calorimeter propereties to exclude

--- a/include/CalibrationHelper.h
+++ b/include/CalibrationHelper.h
@@ -1,6 +1,6 @@
 /**
  *  @file   PandoraAnalysis/include/CalibrationHelper.h
- * 
+ *
  *  @brief  Header file for the calibration helper class.
  */
 
@@ -57,6 +57,9 @@ public:
         LCStrVec    m_hCalBarrelCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
         LCStrVec    m_hCalEndCapCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
         LCStrVec    m_hCalOtherCollectionsSimCaloHit;       ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalBarrelCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalEndCapCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalOtherCollectionsSimCaloHit;       ///< Input simcalorimeter hit collection names
         LCStrVec    m_muonCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
         LCStrVec    m_bCalCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
         LCStrVec    m_lHCalCollectionsSimCaloHit;           ///< Input simcalorimeter hit collection names
@@ -67,7 +70,7 @@ public:
 
     /**
      *  @brief  Constructor
-     * 
+     *
      *  @param  settings the settings
      */
     CalibrationHelper(const Settings &settings);
@@ -79,19 +82,20 @@ public:
 
     /**
      *  @brief  Produces the calibration data
-     * 
+     *
      *  @param  pLCEvent the lc event
      *  @param  particleVector reconstructed particle vector for the lc event
      *  @param  nPfoTargetsTotal number of total targets
      *  @param  nPfoTargetsTracks number of target tracks
      *  @param  nPfoTargetsNeutralHadrons of target neutral hadrons
+     *  @param  nPfoTargetsPhotons of target photons
      *  @param  pfoTargetsEnergyTotal total targets energy
      */
-    void Calibrate(const EVENT::LCEvent *pLCEvent, const ParticleVector &particleVector, const int nPfoTargetsTotal, const int nPfoTargetsTracks, const int nPfoTargetsNeutralHadrons, const float pfoTargetsEnergyTotal);
+    void Calibrate(const EVENT::LCEvent *pLCEvent, const ParticleVector &particleVector, const int nPfoTargetsTotal, const int nPfoTargetsTracks, const int nPfoTargetsNeutralHadrons, const int nPfoTargetsPhotons, const float pfoTargetsEnergyTotal);
 
     /**
      *  @brief  Set branch addresses for calibration variables
-     * 
+     *
      *  @param  pTTree tree to set branch addresses to
      */
     void SetBranchAddresses(TTree *pTTree);
@@ -103,7 +107,7 @@ public:
 
     /**
      *  @brief  Set directory for calibration histograms
-     * 
+     *
      *  @param  pTFile directory to set histograms to
      */
     void SetHistogramDirectories(TFile *pTFile);
@@ -121,14 +125,14 @@ public:
 private:
     /**
      *  @brief  Get the minimum number of HCal layers between any calo hit in the ParticleVector and the edge of the detector
-     * 
+     *
      *  @param  pParticleVector to be examined
      */
     int GetMinNHCalLayersFromEdge(const ParticleVector &pParticleVector) const;
 
     /**
      *  @brief  Read and save the calorimeter hit information for a specific collection
-     * 
+     *
      *  @param  pLCEvent the lc event
      *  @param  collectionNames the collection to be read
      *  @param  hitEnergySum the sum of the hit energy for the collection
@@ -137,7 +141,7 @@ private:
 
     /**
      *  @brief  Read and save the simcalorimeter hit information for a specific collection
-     * 
+     *
      *  @param  pLCEvent the lc event
      *  @param  collectionNames the collection to be read
      *  @param  hitEnergySum the sum of the hit energy for the collection
@@ -146,7 +150,7 @@ private:
 
     /**
      *  @brief  Add the direction corrected SimCaloHits and the direction corrections for a particular collection to separate histograms
-     * 
+     *
      *  @param  pLCEvent a collection in the lc event
      *  @param  collectionNames a collection in the lc event
      *  @param  Barrel, Endcap, Other for the HCal collection
@@ -157,7 +161,7 @@ private:
 
     /**
      *  @brief  Add the direction corrected calo hits for a particular collection to a histogram
-     * 
+     *
      *  @param  pLCEvent a collection in the lc event
      *  @param  collectionNames a collection in the lc event
      *  @param  pTH1F histogram to store direction corrected calo hits
@@ -166,14 +170,14 @@ private:
 
     /**
      *  @brief  Get the minimum number of HCal layers between a calo hit and the edge of the detector
-     * 
+     *
      *  @param  pCaloHit to be examined
      */
     int GetNHCalLayersFromEdge(const EVENT::CalorimeterHit *const pCaloHit) const;
 
     /**
      *  @brief  Get the radial distance between a calo hit in the HCal and the edge of the HCal
-     * 
+     *
      *  @param  pCaloHit to be examined
      *  @param  symmetryOrder of the region of the HCal the hit is in i.e. Barrel, Endcap, Ring
      *  @param  phi0 of the region of the HCal the hit is in i.e. Barrel, Endcap, Ring
@@ -181,7 +185,7 @@ private:
     float GetMaximumRadius(const EVENT::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
 
     /**
-     *  @brief A helper function to access geometry information via DD4HEP 
+     *  @brief A helper function to access geometry information via DD4HEP
      *
      *  @param includeFlag calorimeter propereties to include
      *  @param excludeFlag calorimeter propereties to exclude
@@ -221,6 +225,10 @@ private:
     TH1F           *m_hHCalBarrelDirectionCorrectionSimCaloHit;    ///< AddSimCaloHitEntries setting 1, pass HCal Barrel sim calo hit collections
     TH1F           *m_hHCalEndCapDirectionCorrectionSimCaloHit;    ///< AddSimCaloHitEntries setting 1, pass HCal EndCap sim calo hit collections
     TH1F           *m_hHCalOtherDirectionCorrectionSimCaloHit;     ///< AddSimCaloHitEntries setting 1, pass HCal Other sim calo hit collections
+
+    TH1F           *m_hECalBarrelDirectionCorrectionSimCaloHit;    ///< AddSimCaloHitEntries setting 1, pass ECal Barrel sim calo hit collections
+    TH1F           *m_hECalEndCapDirectionCorrectionSimCaloHit;    ///< AddSimCaloHitEntries setting 1, pass ECal EndCap sim calo hit collections
+    TH1F           *m_hECalOtherDirectionCorrectionSimCaloHit;     ///< AddSimCaloHitEntries setting 1, pass ECal Other sim calo hit collections
 };
 
 } // namespace pandora_analysis

--- a/src/CalibrationHelper.cc
+++ b/src/CalibrationHelper.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/src/CalibrationHelper.cc
- *
+ * 
  *  @brief  Implementation of the calibration helper class.
- *
+ * 
  *  $Log: $
  */
 
@@ -358,7 +358,7 @@ int CalibrationHelper::GetNHCalLayersFromEdge(const EVENT::CalorimeterHit *const
 
     CHT cht(pCaloHit->getType());
 
-
+  
     if (cht.is(CHT::hcal) != true)
     {
         throw CaloHitException();
@@ -626,7 +626,7 @@ void CalibrationHelper::AddDirectionCorrectedCaloHitEntries(const EVENT::LCEvent
 {
     const dd4hep::rec::LayeredCalorimeterData *pECalEndcapExtension(this->GetExtension((DetType::CALORIMETER | DetType::ELECTROMAGNETIC | DetType::ENDCAP), ( DetType::AUXILIARY | DetType::FORWARD)));
     const float zOfEndCap(static_cast<float>(pECalEndcapExtension->extent[2]/dd4hep::mm));
-
+   
     for (EVENT::LCStrVec::const_iterator iter = collectionNames.begin(), iterEnd = collectionNames.end(); iter != iterEnd; ++iter)
     {
         try

--- a/src/CalibrationHelper.cc
+++ b/src/CalibrationHelper.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/src/CalibrationHelper.cc
- * 
+ *
  *  @brief  Implementation of the calibration helper class.
- * 
+ *
  *  $Log: $
  */
 
@@ -98,7 +98,10 @@ CalibrationHelper::CalibrationHelper(const Settings &settings) :
     m_hECalDirectionCorrectedSimCaloHit(NULL),
     m_hHCalBarrelDirectionCorrectionSimCaloHit(NULL),
     m_hHCalEndCapDirectionCorrectionSimCaloHit(NULL),
-    m_hHCalOtherDirectionCorrectionSimCaloHit(NULL)
+    m_hHCalOtherDirectionCorrectionSimCaloHit(NULL),
+    m_hECalBarrelDirectionCorrectionSimCaloHit(NULL),
+    m_hECalEndCapDirectionCorrectionSimCaloHit(NULL),
+    m_hECalOtherDirectionCorrectionSimCaloHit(NULL)
 {
 }
 
@@ -145,6 +148,18 @@ void CalibrationHelper::CreateHistograms()
     m_hHCalOtherDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Direction Correction -> (DirCorr * SimCaloHit)");
     m_hHCalOtherDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
 
+    m_hECalBarrelDirectionCorrectionSimCaloHit = new TH1F("ECalBarrelDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal Barrel (1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalBarrelDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Direction Correction -> (DirCorr * SimCaloHit)");
+    m_hECalBarrelDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
+    m_hECalEndCapDirectionCorrectionSimCaloHit = new TH1F("ECalEndCapDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal EndCap (1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalEndCapDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Direction Correction -> (DirCorr * SimCaloHit)");
+    m_hECalEndCapDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
+    m_hECalOtherDirectionCorrectionSimCaloHit = new TH1F("ECalOtherDirectionCorrectionSimCaloHit", "Distribution of Direction Corrections for SimCaloHits in the ECal Other (1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && Contained in ECal)", 200, 0., 1.0);
+    m_hECalOtherDirectionCorrectionSimCaloHit->GetXaxis()->SetTitle("Direction Correction -> (DirCorr * SimCaloHit)");
+    m_hECalOtherDirectionCorrectionSimCaloHit->GetYaxis()->SetTitle("Entries");
+
     m_hHCalBarrelDirectionCorrectedSimCaloHit = new TH1F("HCalDirectionCorrectedSimCaloHitBarrel", "Distribution of Direction Corrected SimCaloHits in the HCal Barrel (1==nPfoTargetsTotal && 1==nPfoTargetsTracks)", 200, 0., 0.001);
     m_hHCalBarrelDirectionCorrectedSimCaloHit->GetXaxis()->SetTitle("Direction Corrected SimCaloHit Measurement");
     m_hHCalBarrelDirectionCorrectedSimCaloHit->GetYaxis()->SetTitle("Entries");
@@ -181,6 +196,9 @@ void CalibrationHelper::SetHistogramDirectories(TFile *pTFile)
     m_hHCalBarrelDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
     m_hHCalEndCapDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
     m_hHCalOtherDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
+    m_hECalBarrelDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
+    m_hECalEndCapDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
+    m_hECalOtherDirectionCorrectionSimCaloHit->SetDirectory(pTFile);
     m_hHCalBarrelDirectionCorrectedSimCaloHit->SetDirectory(pTFile);
     m_hHCalEndCapDirectionCorrectedSimCaloHit->SetDirectory(pTFile);
     m_hHCalOtherDirectionCorrectedSimCaloHit->SetDirectory(pTFile);
@@ -197,6 +215,9 @@ void CalibrationHelper::WriteHistograms()
     m_hHCalBarrelDirectionCorrectionSimCaloHit->Write();
     m_hHCalEndCapDirectionCorrectionSimCaloHit->Write();
     m_hHCalOtherDirectionCorrectionSimCaloHit->Write();
+    m_hECalBarrelDirectionCorrectionSimCaloHit->Write();
+    m_hECalEndCapDirectionCorrectionSimCaloHit->Write();
+    m_hECalOtherDirectionCorrectionSimCaloHit->Write();
     m_hHCalBarrelDirectionCorrectedSimCaloHit->Write();
     m_hHCalEndCapDirectionCorrectedSimCaloHit->Write();
     m_hHCalOtherDirectionCorrectedSimCaloHit->Write();
@@ -229,8 +250,9 @@ void CalibrationHelper::Clear()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CalibrationHelper::Calibrate(const EVENT::LCEvent *pLCEvent, const ParticleVector &particleVector, 
-    const int nPfoTargetsTotal, const int nPfoTargetsTracks, const int nPfoTargetsNeutralHadrons, const float pfoTargetsEnergyTotal)
+void CalibrationHelper::Calibrate(const EVENT::LCEvent *pLCEvent, const ParticleVector &particleVector,
+    const int nPfoTargetsTotal, const int nPfoTargetsTracks, const int nPfoTargetsNeutralHadrons, const int nPfoTargetsPhotons,
+    const float pfoTargetsEnergyTotal)
 {
     m_pfoMinHCalLayerToEdge = this->GetMinNHCalLayersFromEdge(particleVector);
 
@@ -272,6 +294,13 @@ void CalibrationHelper::Calibrate(const EVENT::LCEvent *pLCEvent, const Particle
         this->AddSimCaloHitEntries(pLCEvent, m_settings.m_hCalBarrelCollectionsSimCaloHit, 0, m_hHCalBarrelDirectionCorrectionSimCaloHit);
         this->AddSimCaloHitEntries(pLCEvent, m_settings.m_hCalEndCapCollectionsSimCaloHit, 0, m_hHCalEndCapDirectionCorrectionSimCaloHit);
         this->AddSimCaloHitEntries(pLCEvent, m_settings.m_hCalOtherCollectionsSimCaloHit, 0, m_hHCalOtherDirectionCorrectionSimCaloHit);
+    }
+
+    if(1==nPfoTargetsTotal && 1==nPfoTargetsPhotons && ((m_totalCaloHitEnergy-m_eCalTotalCaloHitEnergy) < (0.01*pfoTargetsEnergyTotal)))
+    {
+        this->AddSimCaloHitEntries(pLCEvent, m_settings.m_eCalBarrelCollectionsSimCaloHit, 0, m_hECalBarrelDirectionCorrectionSimCaloHit);
+        this->AddSimCaloHitEntries(pLCEvent, m_settings.m_eCalEndCapCollectionsSimCaloHit, 0, m_hECalEndCapDirectionCorrectionSimCaloHit);
+        this->AddSimCaloHitEntries(pLCEvent, m_settings.m_eCalOtherCollectionsSimCaloHit, 0, m_hECalOtherDirectionCorrectionSimCaloHit);
     }
 }
 
@@ -329,7 +358,7 @@ int CalibrationHelper::GetNHCalLayersFromEdge(const EVENT::CalorimeterHit *const
 
     CHT cht(pCaloHit->getType());
 
-  
+
     if (cht.is(CHT::hcal) != true)
     {
         throw CaloHitException();
@@ -597,7 +626,7 @@ void CalibrationHelper::AddDirectionCorrectedCaloHitEntries(const EVENT::LCEvent
 {
     const dd4hep::rec::LayeredCalorimeterData *pECalEndcapExtension(this->GetExtension((DetType::CALORIMETER | DetType::ELECTROMAGNETIC | DetType::ENDCAP), ( DetType::AUXILIARY | DetType::FORWARD)));
     const float zOfEndCap(static_cast<float>(pECalEndcapExtension->extent[2]/dd4hep::mm));
-   
+
     for (EVENT::LCStrVec::const_iterator iter = collectionNames.begin(), iterEnd = collectionNames.end(); iter != iterEnd; ++iter)
     {
         try

--- a/src/PfoAnalysis.cc
+++ b/src/PfoAnalysis.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/src/PfoAnalysis.cc
- * 
+ *
  *  @brief  Implementation of the pfo analysis class.
- * 
+ *
  *  $Log: $
  */
 
@@ -129,64 +129,82 @@ PfoAnalysis::PfoAnalysis() :
                            int(0));
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "ECalCollections", 
+                           "ECalCollections",
                            "Name of the ECal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_eCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "HCalCollections", 
+                           "HCalCollections",
                            "Name of the HCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_hCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "MuonCollections", 
+                           "MuonCollections",
                            "Name of the Muon collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_muonCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "BCalCollections", 
+                           "BCalCollections",
                            "Name of the BCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_bCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "LHCalCollections", 
+                           "LHCalCollections",
                            "Name of the LHCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_lHCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "LCalCollections", 
+                           "LCalCollections",
                            "Name of the LCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_lCalCollections,
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
-                           "ECalCollectionsSimCaloHit" , 
-                           "Name of the ECal collection post Mokka, pre digitisation" , 
-                           m_calibrationHelperSettings.m_eCalCollectionsSimCaloHit , 
+    registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                           "ECalCollectionsSimCaloHit" ,
+                           "Name of the ECal collection post Mokka, pre digitisation" ,
+                           m_calibrationHelperSettings.m_eCalCollectionsSimCaloHit ,
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
-                           "HCalBarrelCollectionsSimCaloHit" , 
-                           "Name of the HCal Barrel collection post Mokka, pre digitisation" , 
-                           m_calibrationHelperSettings.m_hCalBarrelCollectionsSimCaloHit , 
+    registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                           "HCalBarrelCollectionsSimCaloHit" ,
+                           "Name of the HCal Barrel collection post Mokka, pre digitisation" ,
+                           m_calibrationHelperSettings.m_hCalBarrelCollectionsSimCaloHit ,
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
-                           "HCalEndCapCollectionsSimCaloHit" , 
-                           "Name of the HCal EndCap collection post Mokka, pre digitisation" , 
-                           m_calibrationHelperSettings.m_hCalEndCapCollectionsSimCaloHit , 
+    registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                           "HCalEndCapCollectionsSimCaloHit" ,
+                           "Name of the HCal EndCap collection post Mokka, pre digitisation" ,
+                           m_calibrationHelperSettings.m_hCalEndCapCollectionsSimCaloHit ,
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
-                           "HCalOtherCollectionsSimCaloHit" , 
-                           "Name of the HCal Other collection post Mokka, pre digitisation" , 
-                           m_calibrationHelperSettings.m_hCalOtherCollectionsSimCaloHit , 
+    registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                           "HCalOtherCollectionsSimCaloHit" ,
+                           "Name of the HCal Other collection post Mokka, pre digitisation" ,
+                           m_calibrationHelperSettings.m_hCalOtherCollectionsSimCaloHit ,
                            LCStrVec());
+
+     registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                            "ECalBarrelCollectionsSimCaloHit" ,
+                            "Name of the ECal Barrel collection post Mokka, pre digitisation" ,
+                            m_calibrationHelperSettings.m_eCalBarrelCollectionsSimCaloHit ,
+                            LCStrVec());
+
+     registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                            "ECalEndCapCollectionsSimCaloHit" ,
+                            "Name of the ECal EndCap collection post Mokka, pre digitisation" ,
+                            m_calibrationHelperSettings.m_eCalEndCapCollectionsSimCaloHit ,
+                            LCStrVec());
+
+     registerInputCollections(LCIO::SIMCALORIMETERHIT,
+                            "ECalOtherCollectionsSimCaloHit" ,
+                            "Name of the ECal Other collection post Mokka, pre digitisation" ,
+                            m_calibrationHelperSettings.m_eCalOtherCollectionsSimCaloHit ,
+                            LCStrVec());
 
     registerInputCollections(LCIO::SIMCALORIMETERHIT,
                            "MuonCollectionsSimCaloHit" ,
@@ -318,7 +336,7 @@ void PfoAnalysis::processEvent(EVENT::LCEvent *pLCEvent)
     this->PerformPfoAnalysis();
 
     if (m_pCalibrationHelper)
-        m_pCalibrationHelper->Calibrate(pLCEvent, m_pfoVector, m_nPfoTargetsTotal, m_nPfoTargetsTracks, m_nPfoTargetsNeutralHadrons, m_pfoTargetsEnergyTotal);
+        m_pCalibrationHelper->Calibrate(pLCEvent, m_pfoVector, m_nPfoTargetsTotal, m_nPfoTargetsTracks, m_nPfoTargetsNeutralHadrons, m_nPfoTargetsPhotons, m_pfoTargetsEnergyTotal);
 
     m_pTTree->Fill();
 }

--- a/src/PfoAnalysis.cc
+++ b/src/PfoAnalysis.cc
@@ -1,8 +1,8 @@
 /**
  *  @file   PandoraAnalysis/src/PfoAnalysis.cc
- *
+ * 
  *  @brief  Implementation of the pfo analysis class.
- *
+ * 
  *  $Log: $
  */
 
@@ -129,63 +129,63 @@ PfoAnalysis::PfoAnalysis() :
                            int(0));
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "ECalCollections",
+                           "ECalCollections", 
                            "Name of the ECal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_eCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "HCalCollections",
+                           "HCalCollections", 
                            "Name of the HCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_hCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "MuonCollections",
+                           "MuonCollections", 
                            "Name of the Muon collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_muonCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "BCalCollections",
+                           "BCalCollections", 
                            "Name of the BCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_bCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "LHCalCollections",
+                           "LHCalCollections", 
                            "Name of the LHCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_lHCalCollections,
                            LCStrVec());
 
     registerInputCollections(LCIO::CALORIMETERHIT,
-                           "LCalCollections",
+                           "LCalCollections", 
                            "Name of the LCal collection of calo hits used to form clusters",
                            m_calibrationHelperSettings.m_lCalCollections,
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT,
-                           "ECalCollectionsSimCaloHit" ,
-                           "Name of the ECal collection post Mokka, pre digitisation" ,
-                           m_calibrationHelperSettings.m_eCalCollectionsSimCaloHit ,
+    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
+                           "ECalCollectionsSimCaloHit" , 
+                           "Name of the ECal collection post Mokka, pre digitisation" , 
+                           m_calibrationHelperSettings.m_eCalCollectionsSimCaloHit , 
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT,
-                           "HCalBarrelCollectionsSimCaloHit" ,
-                           "Name of the HCal Barrel collection post Mokka, pre digitisation" ,
-                           m_calibrationHelperSettings.m_hCalBarrelCollectionsSimCaloHit ,
+    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
+                           "HCalBarrelCollectionsSimCaloHit" , 
+                           "Name of the HCal Barrel collection post Mokka, pre digitisation" , 
+                           m_calibrationHelperSettings.m_hCalBarrelCollectionsSimCaloHit , 
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT,
-                           "HCalEndCapCollectionsSimCaloHit" ,
-                           "Name of the HCal EndCap collection post Mokka, pre digitisation" ,
-                           m_calibrationHelperSettings.m_hCalEndCapCollectionsSimCaloHit ,
+    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
+                           "HCalEndCapCollectionsSimCaloHit" , 
+                           "Name of the HCal EndCap collection post Mokka, pre digitisation" , 
+                           m_calibrationHelperSettings.m_hCalEndCapCollectionsSimCaloHit , 
                            LCStrVec());
 
-    registerInputCollections(LCIO::SIMCALORIMETERHIT,
-                           "HCalOtherCollectionsSimCaloHit" ,
-                           "Name of the HCal Other collection post Mokka, pre digitisation" ,
-                           m_calibrationHelperSettings.m_hCalOtherCollectionsSimCaloHit ,
+    registerInputCollections(LCIO::SIMCALORIMETERHIT, 
+                           "HCalOtherCollectionsSimCaloHit" , 
+                           "Name of the HCal Other collection post Mokka, pre digitisation" , 
+                           m_calibrationHelperSettings.m_hCalOtherCollectionsSimCaloHit , 
                            LCStrVec());
 
      registerInputCollections(LCIO::SIMCALORIMETERHIT,


### PR DESCRIPTION
Hello Cambridge !

After a first run to calibrate the ecal in the current full LC reconstruction, it appears that the ecal calibration requires to have separate calibration for the three different detector regions (barrel/endcap/ring). 

Following the current calibration procedure, we observed two different populations for 100 GeV photons (see [pdg22_before_calib_s4.pdf](https://github.com/PandoraPFA/LCPandoraAnalysis/files/1217710/pdg22_before_calib_s4.pdf) ), one for the barrel (blue) and one for the endcap (red), the black distribution being the sum. The global shift of 5% to higher energies is expected and is due to the ecal sensitive part increase of 5% in our new simulation models (ILD_l/s4_v02) ... I changed the ecal digitization calibration so that we can now calibrate the two regions separately.

I also added a new binary ECalDigitisation_DirectionCorrectionDistribution, almost a copy/paste/adapt of the hcal one to calibrate the ecal ring using the direction corrected distribution. Does that makes sense for you ?