### PR TITLE
Change hcal leakage cut with new variable

### DIFF
--- a/include/CalibrationHelper.h
+++ b/include/CalibrationHelper.h
@@ -129,6 +129,14 @@ private:
      *  @param  pParticleVector to be examined
      */
     int GetMinNHCalLayersFromEdge(const ParticleVector &pParticleVector) const;
+    
+    /**
+     *  @brief  Get the calo hit energy in the last hcal layers of the detector 
+     * 
+     *  @param  pLCEvent the lc event
+     *  @param  collectionNames the collection to be read
+     */
+    float GetHCalCaloHitEnergyFromEdge(const EVENT::LCEvent *pLCEvent, const EVENT::LCStrVec &collectionNames) const;
 
     /**
      *  @brief  Read and save the calorimeter hit information for a specific collection
@@ -195,6 +203,7 @@ private:
     const Settings  m_settings;                                    ///< The calibration helper settings
 
     int             m_pfoMinHCalLayerToEdge;                       ///< GetNHCalLayersFromEdge
+    int             m_hCalCaloHitEnergyFromEdge;                   ///< GetHCalCaloHitEnergyFromEdge
 
     float           m_totalCaloHitEnergy;                          ///< Sum outputs from ReadCaloHitEnergies
     float           m_eCalTotalCaloHitEnergy;                      ///< ReadCaloHitEnergies


### PR DESCRIPTION
- New variable added in CalibrationHelper to compute a new estimate of kaon0L leakage from hcal (hCalCaloHitEnergyFromEdge). This variable do not use PFO information and give the same results for calibration purpose. By not using the PFO information, my calibration procedure speedup is increased by a huge factor (5 min VS 1 or 2 hours), justifying this PR...
- HCalDigitisation_ContainedEvents updated to make use of this variable. This also leaded to remove argument -f for number of hcal layers, which is not needed anymore.

Note that the old variable pfoMinHCalLayerToEdge is kept in the root file, in case other studies still need this variable.