### PR TITLE
Pfo analysis updates

### DIFF
--- a/include/CalibrationHelper.h
+++ b/include/CalibrationHelper.h
@@ -46,27 +46,30 @@ public:
          */
         Settings();
 
-        LCStrVec    m_eCalCollections;                      ///< Input calorimeter hit collection names
-        LCStrVec    m_hCalCollections;                      ///< Input calorimeter hit collection names
-        LCStrVec    m_muonCollections;                      ///< Input calorimeter hit collection names
-        LCStrVec    m_bCalCollections;                      ///< Input calorimeter hit collection names
-        LCStrVec    m_lHCalCollections;                     ///< Input calorimeter hit collection names
-        LCStrVec    m_lCalCollections;                      ///< Input calorimeter hit collection names
+        LCStrVec    m_eCalCollections{};                      ///< Input calorimeter hit collection names
+        LCStrVec    m_hCalCollections{};                      ///< Input calorimeter hit collection names
+        LCStrVec    m_muonCollections{};                      ///< Input calorimeter hit collection names
+        LCStrVec    m_bCalCollections{};                      ///< Input calorimeter hit collection names
+        LCStrVec    m_lHCalCollections{};                     ///< Input calorimeter hit collection names
+        LCStrVec    m_lCalCollections{};                      ///< Input calorimeter hit collection names
 
-        LCStrVec    m_eCalCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
-        LCStrVec    m_hCalBarrelCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
-        LCStrVec    m_hCalEndCapCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
-        LCStrVec    m_hCalOtherCollectionsSimCaloHit;       ///< Input simcalorimeter hit collection names
-        LCStrVec    m_eCalBarrelCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
-        LCStrVec    m_eCalEndCapCollectionsSimCaloHit;      ///< Input simcalorimeter hit collection names
-        LCStrVec    m_eCalOtherCollectionsSimCaloHit;       ///< Input simcalorimeter hit collection names
-        LCStrVec    m_muonCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
-        LCStrVec    m_bCalCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
-        LCStrVec    m_lHCalCollectionsSimCaloHit;           ///< Input simcalorimeter hit collection names
-        LCStrVec    m_lCalCollectionsSimCaloHit;            ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalCollectionsSimCaloHit{};            ///< Input simcalorimeter hit collection names
+        LCStrVec    m_hCalBarrelCollectionsSimCaloHit{};      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_hCalEndCapCollectionsSimCaloHit{};      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_hCalOtherCollectionsSimCaloHit{};       ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalBarrelCollectionsSimCaloHit{};      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalEndCapCollectionsSimCaloHit{};      ///< Input simcalorimeter hit collection names
+        LCStrVec    m_eCalOtherCollectionsSimCaloHit{};       ///< Input simcalorimeter hit collection names
+        LCStrVec    m_muonCollectionsSimCaloHit{};            ///< Input simcalorimeter hit collection names
+        LCStrVec    m_bCalCollectionsSimCaloHit{};            ///< Input simcalorimeter hit collection names
+        LCStrVec    m_lHCalCollectionsSimCaloHit{};           ///< Input simcalorimeter hit collection names
+        LCStrVec    m_lCalCollectionsSimCaloHit{};            ///< Input simcalorimeter hit collection names
     };
 
     typedef std::vector<const EVENT::ReconstructedParticle *> ParticleVector;
+    
+    CalibrationHelper(const CalibrationHelper&) = delete;
+    CalibrationHelper& operator=(const CalibrationHelper&) = delete;
 
     /**
      *  @brief  Constructor

--- a/include/PfoAnalysis.h
+++ b/include/PfoAnalysis.h
@@ -30,6 +30,9 @@ class TTree;
 class PfoAnalysis : public marlin::Processor
 {
 public:
+    PfoAnalysis(const PfoAnalysis&) = delete;
+    PfoAnalysis& operator=(const PfoAnalysis&) = delete;
+  
     /**
      *  @brief  Default constructor
      */
@@ -123,11 +126,11 @@ private:
     int                 m_nRunSum;                              ///< 
     int                 m_nEvtSum;                              ///< 
 
-    std::string         m_inputPfoCollection;                   ///< 
-    std::string         m_mcParticleCollection;                 ///< 
+    std::string         m_inputPfoCollection{};                 ///< 
+    std::string         m_mcParticleCollection{};               ///< 
 
     int                 m_printing;                             ///< 
-    std::string         m_rootFile;                             ///< 
+    std::string         m_rootFile{};                           ///< 
 
     int                 m_lookForQuarksWithMotherZ;             ///< 
 
@@ -135,8 +138,8 @@ private:
     float               m_mcPfoSelectionMomentum;               ///< 
     float               m_mcPfoSelectionLowEnergyNPCutOff;      ///< 
 
-    ParticleVector      m_pfoVector;                            ///< 
-    MCParticleVector    m_pfoTargetVector;                      ///< 
+    ParticleVector      m_pfoVector{};                          ///< 
+    MCParticleVector    m_pfoTargetVector{};                    ///< 
 
     int                 m_nPfosTotal;                           ///< 
     int                 m_nPfosNeutralHadrons;                  ///< 
@@ -157,21 +160,21 @@ private:
     float               m_pfoMassTotal;                         ///< 
 
     typedef std::vector<float> FloatVector;
-    FloatVector         m_pfoEnergies;                          ///< 
-    FloatVector         m_pfoPx;                                ///< 
-    FloatVector         m_pfoPy;                                ///< 
-    FloatVector         m_pfoPz;                                ///< 
-    FloatVector         m_pfoCosTheta;                          ///< 
+    FloatVector         m_pfoEnergies{};                        ///< 
+    FloatVector         m_pfoPx{};                              ///< 
+    FloatVector         m_pfoPy{};                              ///< 
+    FloatVector         m_pfoPz{};                              ///< 
+    FloatVector         m_pfoCosTheta{};                        ///< 
 
-    FloatVector         m_pfoTargetEnergies;                    ///< 
-    FloatVector         m_pfoTargetPx;                          ///< 
-    FloatVector         m_pfoTargetPy;                          ///< 
-    FloatVector         m_pfoTargetPz;                          ///< 
-    FloatVector         m_pfoTargetCosTheta;                    ///< 
+    FloatVector         m_pfoTargetEnergies{};                  ///< 
+    FloatVector         m_pfoTargetPx{};                        ///< 
+    FloatVector         m_pfoTargetPy{};                        ///< 
+    FloatVector         m_pfoTargetPz{};                        ///< 
+    FloatVector         m_pfoTargetCosTheta{};                  ///< 
 
     typedef std::vector<int> IntVector;
-    IntVector           m_pfoPdgCodes;                          ///< 
-    IntVector           m_pfoTargetPdgCodes;                    ///< 
+    IntVector           m_pfoPdgCodes{};                        ///< 
+    IntVector           m_pfoTargetPdgCodes{};                  ///< 
 
     int                 m_nPfoTargetsTotal;                     ///< 
     int                 m_nPfoTargetsNeutralHadrons;            ///< 
@@ -195,10 +198,10 @@ private:
     float               m_thrust;                               ///< 
     int                 m_qPdg;                                 ///< 
 
-    TFile              *m_pTFile;                               ///< 
-    TTree              *m_pTTree;                               ///< 
-    TH1F               *m_hPfoEnergySum;                        ///< 
-    TH1F               *m_hPfoEnergySumL7A;                     ///< 
+    TFile              *m_pTFile{};                             ///< 
+    TTree              *m_pTTree{};                             ///< 
+    TH1F               *m_hPfoEnergySum{};                      ///< 
+    TH1F               *m_hPfoEnergySumL7A{};                   ///< 
 
     int                                             m_collectCalibrationDetails;        ///< Whether to collect calibration details
     pandora_analysis::CalibrationHelper            *m_pCalibrationHelper;               ///< The address of the calibration helper

--- a/src/PfoAnalysis.cc
+++ b/src/PfoAnalysis.cc
@@ -535,18 +535,27 @@ void PfoAnalysis::MakeQuarkVariables(EVENT::LCEvent *pLCEvent)
             const int absPdgCode(std::abs(pMCParticle->getPDG()));
 
             // By default, the primary quarks are the ones without any parents
-            if (!m_lookForQuarksWithMotherZ)
+            if (0 == m_lookForQuarksWithMotherZ)
             {
                 if ((absPdgCode >= 1) && (absPdgCode <= 6) && pMCParticle->getParents().empty())
                     mcQuarkVector.push_back(pMCParticle);
             }
-            else
+            else if (1 == m_lookForQuarksWithMotherZ)
             {
                 // For MC files generated in the SLIC environment, the primary quarks have parents; the mother should be the Z-boson
                 if ((absPdgCode >= 1) && (absPdgCode <= 6))
                 {
                     if ((pMCParticle->getParents().size() == 1) && ((pMCParticle->getParents())[0]->getPDG() == 23))
                         mcQuarkVector.push_back(pMCParticle);
+                }
+            }
+            else if (2 == m_lookForQuarksWithMotherZ)
+            {
+                // 2018 MC production: uds(bs) samples have been re-produced with Whizard 2.
+                // MC history has been changed and follow the condition below
+                if (!(pMCParticle->getParents().empty()) && (pMCParticle->getParents())[0]->getParents().empty())
+                {
+                    mcQuarkVector.push_back(pMCParticle);
                 }
             }
         }

--- a/src/PfoAnalysis.cc
+++ b/src/PfoAnalysis.cc
@@ -645,9 +645,9 @@ void PfoAnalysis::PerformPfoAnalysis()
     float momTot[3] = {0.f, 0.f, 0.f};
 
     // Extract quantities relating to reconstructed pfos
-    for (ParticleVector::const_iterator iter = m_pfoVector.begin(), iterEnd = m_pfoVector.end(); iter != iterEnd; ++iter)
+    for (ParticleVector::const_iterator piter = m_pfoVector.begin(), piterEnd = m_pfoVector.end(); piter != piterEnd; ++piter)
     {
-        const EVENT::ReconstructedParticle *pPfo = *iter;
+        const EVENT::ReconstructedParticle *pPfo = *piter;
 
         ++m_nPfosTotal;
         m_pfoEnergyTotal += pPfo->getEnergy();
@@ -674,9 +674,9 @@ void PfoAnalysis::PerformPfoAnalysis()
             float cellEnergySum(0.f);
             const EVENT::ClusterVec &clusterVec(pPfo->getClusters());
 
-            for (EVENT::ClusterVec::const_iterator iter = clusterVec.begin(), iterEnd = clusterVec.end(); iter != iterEnd; ++iter)
+            for (EVENT::ClusterVec::const_iterator cliter = clusterVec.begin(), cliterEnd = clusterVec.end(); cliter != cliterEnd; ++cliter)
             {
-                const EVENT::CalorimeterHitVec &calorimeterHitVec((*iter)->getCalorimeterHits());
+                const EVENT::CalorimeterHitVec &calorimeterHitVec((*cliter)->getCalorimeterHits());
 
                 for (EVENT::CalorimeterHitVec::const_iterator hitIter = calorimeterHitVec.begin(), hitIterEnd = calorimeterHitVec.end(); hitIter != hitIterEnd; ++hitIter)
                 {


### PR DESCRIPTION
Hi Cambridge !

We are currently reproducing the standard uds samples (same as Steve's grid directory Z_uds) but with Whizard 2, also with some c and b di-jets.
The MC particle is now a bit different in the generator files and finding the original quarks is also different.

Changes in this pull request:

- Added a third option with processor parameter `m_lookForQuarksWithMotherZ` to match the new MC particle history
- Fixed some compiler warnings (mainly `-Weffc++`) in `CalibrationHelper` and `PfoAnalysis`

The changes are backward compatible.