### PR TITLE
Make doxygen cmake config work with CMake >= 3.17

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,6 +15,7 @@ IF( DOXYGEN_FOUND )
     # directories to search for documentation
     SET( DOX_INPUT ../include ../src )
 
+    FILE(GLOB DOXYGEN_SOURCES ../include/* ../src/*)
 
     # custom command to build documentation
     ADD_CUSTOM_COMMAND(
@@ -26,7 +27,7 @@ IF( DOXYGEN_FOUND )
                 "${DOXYGEN_EXECUTABLE}"
         WORKING_DIRECTORY "${DOC_SRC_DIR}"
         COMMENT "Building API Documentation..."
-        DEPENDS Doxyfile CMakeLists.txt ../include/* ../src/*
+        DEPENDS Doxyfile CMakeLists.txt ${DOXYGEN_SOURCES}
     )
 
     # add doc target


### PR DESCRIPTION
Newer versions of cmake no longer do the implicit globing in `DEPENDS`. Moving this outside as a quick fix, in order to build and install the documentation even with newer versions of CMake